### PR TITLE
[BC break] Rename indexed() and keys() to list() and listKeys()

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,22 +269,7 @@ assert($expected === iterator_to_array($zip));
 ?>
 ```
 
-#### keys
-Uses keys as values, and the new keys are indexes.
-```php
-<?php
-$array = [
-    'a' => 'A',
-    'b' => 'B',
-    'c' => 'C',
-];
-$keys = iter($array)->keys();
-$expected = ['a', 'b', 'c'];
-assert($expected === iterator_to_array($keys));
-?>
-```
-
-#### indexed
+#### list
 Converts all keys to integers, starting from 0.
 ```php
 <?php
@@ -293,9 +278,24 @@ $array = [
     'b' => 'B',
     'c' => 'C',
 ];
-$indexed = iter($array)->indexed();
+$indexed = iter($array)->list();
 $expected = ['A', 'B', 'C'];
 assert($expected === iterator_to_array($indexed));
+?>
+```
+
+#### listKeys
+Uses keys as values, and indexes them from 0.
+```php
+<?php
+$array = [
+    'a' => 'A',
+    'b' => 'B',
+    'c' => 'C',
+];
+$keys = iter($array)->listKeys();
+$expected = ['a', 'b', 'c'];
+assert($expected === iterator_to_array($keys));
 ?>
 ```
 

--- a/src/Iterator.php
+++ b/src/Iterator.php
@@ -162,18 +162,18 @@ interface Iterator extends \Iterator, \Countable
     public function zip($other, ...$others): self;
 
     /**
-     * Returns the keys as indexed values.
+     * Creates a list with all keys set to integers, starting from 0.
      *
      * @return \BartFeenstra\Functional\Iterator
      */
-    public function keys(): self;
+    public function list(): self;
 
     /**
-     * Converts all keys to integers, starting from 0.
+     * Returns the keys as indexed values, starting from 0.
      *
      * @return \BartFeenstra\Functional\Iterator
      */
-    public function indexed(): self;
+    public function listKeys(): self;
 
     /**
      * Swaps keys and values.

--- a/src/IteratorTrait.php
+++ b/src/IteratorTrait.php
@@ -132,14 +132,14 @@ trait IteratorTrait
         return new ZipIterator($this, ...func_get_args());
     }
 
-    public function keys(): Iterator
-    {
-        return new KeyIterator($this);
-    }
-
-    public function indexed(): Iterator
+    public function list(): Iterator
     {
         return new IndexedIterator($this);
+    }
+
+    public function listKeys(): Iterator
+    {
+        return new KeyIterator($this);
     }
 
     public function flip(): Iterator
@@ -209,7 +209,7 @@ trait IteratorTrait
     {
         $iterator = $this;
         do {
-            $iterator = new ChainIterator(...$iterator->indexed());
+            $iterator = new ChainIterator(...$iterator->list());
             $levels--;
         } while ($levels);
         return $iterator;

--- a/tests/src/IteratorTraitTest.php
+++ b/tests/src/IteratorTraitTest.php
@@ -342,24 +342,9 @@ final class IteratorTraitTest extends TestCase
     }
 
     /**
-     * @covers ::keys
+     * @covers ::list
      */
-    public function testKeys()
-    {
-        $array = [
-            'a' => 'A',
-            'b' => 'B',
-            'c' => 'C',
-        ];
-        $iterator = new ArrayIterator($array);
-        $expected = ['a', 'b', 'c'];
-        $this->assertSame($expected, iterator_to_array($iterator->keys()));
-    }
-
-    /**
-     * @covers ::indexed
-     */
-    public function testIndexed()
+    public function testList()
     {
         $array = [
             'a' => 'A',
@@ -368,7 +353,22 @@ final class IteratorTraitTest extends TestCase
         ];
         $iterator = new ArrayIterator($array);
         $expected = ['A', 'B', 'C'];
-        $this->assertSame($expected, iterator_to_array($iterator->indexed()));
+        $this->assertSame($expected, iterator_to_array($iterator->list()));
+    }
+
+    /**
+     * @covers ::listKeys
+     */
+    public function testListKeys()
+    {
+        $array = [
+            'a' => 'A',
+            'b' => 'B',
+            'c' => 'C',
+        ];
+        $iterator = new ArrayIterator($array);
+        $expected = ['a', 'b', 'c'];
+        $this->assertSame($expected, iterator_to_array($iterator->listKeys()));
     }
 
     /**


### PR DESCRIPTION
Rename indexed() and keys() to list() and listKeys() for consistency with map() and mapKeys().

This obsoletes https://github.com/bartfeenstra/fu-php/pull/44.