### PR TITLE
Convert variadic parameters to arrays.

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ Combines the values of two or more iterables into [tuples](https://en.wikipedia.
 $one = [3, 1, 4];
 $two = [1, 5, 9];
 $three = [2, 9, 2];
-$zip = iter($one)->zip($two, $three);
+$zip = iter($one)->zip([$two, $three]);
 $expected = [[3, 1, 2], [1, 5, 9], [4, 9, 2]];
 assert($expected === iterator_to_array($zip));
 ?>
@@ -406,7 +406,7 @@ Chains other iterables to an existing iterator, and re-indexes the values.
 $arrayOne = [3, 1, 4];
 $arrayTwo = [1, 5, 9];
 $arrayThree = [2, 6, 5];
-$iterator = iter($arrayOne)->chain($arrayTwo, $arrayThree);
+$iterator = iter($arrayOne)->chain([$arrayTwo, $arrayThree]);
 $expected = [3, 1, 4, 1, 5, 9, 2, 6, 5];
 assert($expected === $iterator->toArray());
 ?>
@@ -457,13 +457,13 @@ Complex `try`/`catch` blocks can be replaced and converted to [`Result`](#the-re
 $result = F\try_except(function () {/** ... */});
 
 // Try executing a callable, catch all Foo, Bar, Baz, and Qux exceptions, and output a Result.
-$result = F\try_except(function () {/** ... */}, Foo::class, Bar::class, Baz::class, Qux::class);
+$result = F\try_except(function () {/** ... */}, [Foo::class, Bar::class, Baz::class, Qux::class]);
 
 // Try executing a callable at most twice, catch all exceptions, and output a Result.
 $result = F\retry_except(function () {/** ... */});
 
 // Try executing a callable at most 5 times, catch all Foo, Bar, Baz, and Qux exceptions, and output a Result.
-$result = F\retry_except(function () {/** ... */}, 5, Foo::class, Bar::class, Baz::class, Qux::class);
+$result = F\retry_except(function () {/** ... */}, 5, [Foo::class, Bar::class, Baz::class, Qux::class]);
 ?>
 ```
 
@@ -507,13 +507,13 @@ $predicate = P\lt(15);
 $predicate = P\le(666);
 
 // All values that are instances of Foo, Bar, Baz, or Qux.
-$predicate = P\instance_of(Foo::class, Bar::class, Baz::class, Qux::class);
+$predicate = P\instance_of([Foo::class, Bar::class, Baz::class, Qux::class]);
 
 // One or more values are lesser than 0 OR greater than 9.
-$predicate = P\any(P\lt(0), P\gt(9));
+$predicate = P\any([P\lt(0), P\gt(9)]);
 
 // All values are greater than 0 AND lesser than 9.
-$predicate = P\all(P\gt(0), P\lt(9));
+$predicate = P\all([P\gt(0), P\lt(9)]);
 
 // All values different from "Apples and oranges".
 $predicate = P\not(P\eq('Apples and oranges'));

--- a/src/Iterable/ChainIterator.php
+++ b/src/Iterable/ChainIterator.php
@@ -21,24 +21,27 @@ class ChainIterator implements Iterator
     /**
      * Constructs a new instance.
      *
-     * @param mixed[] ...$iterables
+     * @param mixed[] $iterables
+     *   An array of any values taken by \BartFeenstra\Functional\iter().
      *
      * @throws \BartFeenstra\Functional\Iterable\InvalidIterable
      */
-    public function __construct(...$iterables)
+    // @todo What if we want to pass on an iterable of iterables?
+    public function __construct(array $iterables)
     {
         // Use an empty array as default iterable, to simplify the code in this class.
-        $this->append(...$iterables ?: [[]]);
+        $this->append($iterables ?: [[]]);
     }
 
     /**
      * Appends an iterable to the chain.
      *
-     * @param mixed[] ...$iterables
+     * @param mixed[] $iterables
+     *   An array of any values taken by \BartFeenstra\Functional\iter().
      *
      * @return $this
      */
-    public function append(...$iterables): self
+    public function append(array $iterables): self
     {
         foreach ($iterables as $iterable) {
             $this->iterators[] = iter($iterable);

--- a/src/Iterable/Iterator.php
+++ b/src/Iterable/Iterator.php
@@ -161,14 +161,12 @@ interface Iterator extends \Iterator, \Countable
     /**
      * Zips each value into a tuple with corresponding values from each of the other traversables.
      *
-     * @param mixed $other
-     *   Any value taken by \BartFeenstra\Functional\iter().
-     * @param mixed ...$others
-     *   Any values taken by \BartFeenstra\Functional\iter().
+     * @param mixed[] $iterables
+     *   An array of any values taken by \BartFeenstra\Functional\iter().
      *
      * @return \BartFeenstra\Functional\Iterable\Iterator
      */
-    public function zip($other, ...$others): self;
+    public function zip(array $iterables): self;
 
     /**
      * Creates a list with all keys set to integers, starting from 0.
@@ -228,7 +226,7 @@ interface Iterator extends \Iterator, \Countable
     /**
      * Sorts items by their values.
      *
-     * @param  callable $sort
+     * @param callable $sort
      *   Signature: function(mixed $value1, mixed $value2): bool. Defaults to NULL for a regular sort.
      *
      * @return \BartFeenstra\Functional\Iterable\Iterator
@@ -238,7 +236,7 @@ interface Iterator extends \Iterator, \Countable
     /**
      * Sorts items by their keys.
      *
-     * @param  callable $sort
+     * @param callable $sort
      *   Signature: function(mixed $key1, mixed $key2): bool. Defaults to NULL for a regular sort.
      *
      * @return \BartFeenstra\Functional\Iterable\Iterator
@@ -248,22 +246,28 @@ interface Iterator extends \Iterator, \Countable
     /**
      * Chains other iterables to this iterator, and re-indexes the values.
      *
+     * @param mixed[] $iterables
+     *   An array of any values taken by \BartFeenstra\Functional\iter().
+     *
      * @return \BartFeenstra\Functional\Iterable\Iterator
      *
      * @throws \BartFeenstra\Functional\Iterable\InvalidIterable
      *   Thrown if one of the items is not an iterable.
      */
-    public function chain(...$iterables): self;
+    public function chain(array $iterables): self;
 
     /**
      * Merges other iterables into this iterator, where later values override earlier ones with the same keys.
      *
+     * @param mixed[] $iterables
+     *   An array of any values taken by \BartFeenstra\Functional\iter().
+     *
      * @return \BartFeenstra\Functional\Iterable\Iterator
      *
      * @throws \BartFeenstra\Functional\Iterable\InvalidIterable
      *   Thrown if one of the items is not an iterable.
      */
-    public function merge(...$iterables): self;
+    public function merge(array $iterables): self;
 
     /**
      * Flattens the iterables contained by this iterator into a single new iterator.

--- a/src/Iterable/IteratorTrait.php
+++ b/src/Iterable/IteratorTrait.php
@@ -137,9 +137,10 @@ trait IteratorTrait
         return new InfiniteIterator($this);
     }
 
-    public function zip($other, ...$others): Iterator
+    public function zip(array $iterables): Iterator
     {
-        return new ZipIterator($this, ...func_get_args());
+        array_unshift($iterables, $this);
+        return new ZipIterator($iterables);
     }
 
     public function list(): Iterator
@@ -211,22 +212,23 @@ trait IteratorTrait
         return new ArrayIterator($array);
     }
 
-    public function chain(...$iterables): Iterator
+    public function chain(array $iterables): Iterator
     {
-        return new ChainIterator($this, ...$iterables);
+        array_unshift($iterables, $this);
+        return new ChainIterator($iterables);
     }
 
-    public function merge(...$iterables): Iterator
+    public function merge(array $iterables): Iterator
     {
-        return new ArrayIterator(array_merge(...
-            array_map('\BartFeenstra\Functional\Iterable\ensure_array', array_merge([$this], $iterables))));
+        array_unshift($iterables, $this);
+        return new ArrayIterator(array_merge(...array_map('\BartFeenstra\Functional\Iterable\ensure_array', $iterables)));
     }
 
     public function flatten(int $levels = 1): Iterator
     {
         $iterator = $this;
         do {
-            $iterator = new ChainIterator(...$iterator->list());
+            $iterator = new ChainIterator($iterator->list()->toArray());
             $levels--;
         } while ($levels);
         return $iterator;

--- a/src/Iterable/ZipIterator.php
+++ b/src/Iterable/ZipIterator.php
@@ -19,16 +19,12 @@ final class ZipIterator implements Iterator
     /**
      * Constructs a new instance.
      *
-     * @param mixed $one
-     *   Any value taken by \BartFeenstra\Functional\iter().
-     * @param mixed $two
-     *   Any value taken by \BartFeenstra\Functional\iter().
-     * @param mixed ...$more
+     * @param mixed[] $iterables
      *   Any values taken by \BartFeenstra\Functional\iter().
      */
-    public function __construct($one, $two, ...$more)
+    public function __construct(array $iterables)
     {
-        $this->iterators = array_map('\BartFeenstra\Functional\Iterable\iter', func_get_args());
+        $this->iterators = array_map('\BartFeenstra\Functional\Iterable\iter', $iterables);
     }
 
     public function current()

--- a/src/Iterable/functions.php
+++ b/src/Iterable/functions.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace BartFeenstra\Functional\Iterable;
 
+use function BartFeenstra\Functional\type;
+
 /**
  * Creates an iterator for iterable data.
  *

--- a/src/Predicate/functions.php
+++ b/src/Predicate/functions.php
@@ -147,15 +147,13 @@ function le($other): callable
 /**
  * Gets a predicate to check if an object or class name is an instance of one or more types.
  *
- * @param string $type
- * @param string ..$types
+ * @param string[] $types
  *
  * @return callable
  *   A predicate.
  */
-function instance_of(string $type, string ...$types): callable
+function instance_of(array $types): callable
 {
-    $types = func_get_args();
     return function ($value) use ($types) {
         foreach ($types as $type) {
             if ($value instanceof $type or is_subclass_of($value, $type) or $value === $type) {
@@ -169,15 +167,13 @@ function instance_of(string $type, string ...$types): callable
 /**
  * Gets a predicate that wraps other predicates and checks at least one of them matches.
  *
- * @param callable $predicate
- * @param callable[] ...$predicates
+ * @param callable[] $predicates
  *
  * @return callable
  *   A predicate.
  */
-function any(callable $predicate, callable ...$predicates): callable
+function any(array $predicates): callable
 {
-    $predicates = func_get_args();
     return function ($value) use ($predicates) {
         foreach ($predicates as $predicate) {
             if ($predicate($value)) {
@@ -191,15 +187,13 @@ function any(callable $predicate, callable ...$predicates): callable
 /**
  * Gets a predicate that wraps other predicates and checks all of them match.
  *
- * @param callable $predicate
- * @param callable[] ...$predicates
+ * @param callable[] $predicates
  *
  * @return callable
  *   A predicate.
  */
-function all(callable $predicate, callable ...$predicates): callable
+function all(array $predicates): callable
 {
-    $predicates = func_get_args();
     return function ($value) use ($predicates) {
         foreach ($predicates as $predicate) {
             if (!$predicate($value)) {

--- a/src/functions.php
+++ b/src/functions.php
@@ -29,7 +29,7 @@ function type($value): string
  *
  * @param callable $goal
  *   The code to try and execute. Signature: `function(): mixed`.
- * @param string ...$except
+ * @param string[] $except
  *   The fully qualified names of \Throwable implementations to limit the catch to. Any throwable not listed, will not
  *   be caught. If not given, all throwables will be caught.
  *
@@ -38,12 +38,12 @@ function type($value): string
  * @throws \Throwable
  *   If $except is given, any throwable thrown by $goal that is not in $except.
  */
-function try_except(callable $goal, string ...$except): Result
+function try_except(callable $goal, array $except = []): Result
 {
     try {
         return new OkValue($goal());
     } catch (\Throwable $t) {
-        if (!$except or instance_of(...$except)($t)) {
+        if (!$except or instance_of($except)($t)) {
             return new ThrowableError($t);
         }
         throw $t;
@@ -60,7 +60,7 @@ function try_except(callable $goal, string ...$except): Result
  *   The code to try and execute. Signature: `function(): mixed`.
  * @param int|null $attempts
  *   The number of times to try to reach the goal. Use NULL to retry infinitely. Defaults to 2 attempts / 1 retry.
- * @param string ...$except
+ * @param string[] $except
  *   The fully qualified names of \Throwable implementations to limit the catch to. Any throwable not listed, will not
  *   be caught. If not given, all throwables will be caught.
  *
@@ -69,7 +69,7 @@ function try_except(callable $goal, string ...$except): Result
  * @throws \Throwable
  *   If $except is given, any throwable thrown by $goal that is not in $except.
  */
-function retry_except(callable $goal, ?int $attempts = 2, string ...$except): Result
+function retry_except(callable $goal, ?int $attempts = 2, array $except = []): Result
 {
     $retry = true;
     $remainingAttempts = $attempts;
@@ -84,7 +84,7 @@ function retry_except(callable $goal, ?int $attempts = 2, string ...$except): Re
         try {
             return new OkValue($goal());
         } catch (\Throwable $t) {
-            if (!$except or instance_of(...$except)($t)) {
+            if (!$except or instance_of($except)($t)) {
                 if ($retry) {
                     continue;
                 }

--- a/tests/src/FunctionsTest.php
+++ b/tests/src/FunctionsTest.php
@@ -65,7 +65,7 @@ final class FunctionsTest extends TestCase
         };
         $expected = new F\ThrowableError($throwable);
         // Except a parent class, so we make sure the code under test can handle inheritance.
-        $this->assertEquals($expected, F\try_except($goal, \BadFunctionCallException::class));
+        $this->assertEquals($expected, F\try_except($goal, [\BadFunctionCallException::class]));
     }
 
     /**
@@ -77,7 +77,7 @@ final class FunctionsTest extends TestCase
         $goal = function () {
             throw new \RuntimeException();
         };
-        F\try_except($goal, \InvalidArgumentException::class);
+        F\try_except($goal, [\InvalidArgumentException::class]);
     }
 
     /**
@@ -140,7 +140,7 @@ final class FunctionsTest extends TestCase
         };
         $expected = new F\ThrowableError($throwable);
         // Except a parent class, so we make sure the code under test can handle inheritance.
-        $this->assertEquals($expected, F\retry_except($goal, 2, \BadFunctionCallException::class));
+        $this->assertEquals($expected, F\retry_except($goal, 2, [\BadFunctionCallException::class]));
     }
 
     /**
@@ -152,7 +152,7 @@ final class FunctionsTest extends TestCase
         $goal = function () {
             throw new \RuntimeException();
         };
-        F\retry_except($goal, 2, \InvalidArgumentException::class);
+        F\retry_except($goal, 2, [\InvalidArgumentException::class]);
     }
 
     /**

--- a/tests/src/Iterable/ChainIteratorTest.php
+++ b/tests/src/Iterable/ChainIteratorTest.php
@@ -21,7 +21,7 @@ final class ChainIteratorTest extends TestCase
         $arrayOne = [3, 1, 4];
         $arrayTwo = [1, 5, 9];
         $arrayThree = [2, 6, 5];
-        $iterator = new ChainIterator($arrayOne, $arrayTwo, $arrayThree);
+        $iterator = new ChainIterator([$arrayOne, $arrayTwo, $arrayThree]);
         $expected = [3, 1, 4, 1, 5, 9, 2, 6, 5];
         $this->assertSame($expected, $iterator->toArray());
         // Test again, to cover rewinding.
@@ -36,7 +36,7 @@ final class ChainIteratorTest extends TestCase
         $arrayOne = [3, 1, 4];
         $arrayTwo = [];
         $arrayThree = [1, 5, 9];
-        $iterator = new ChainIterator($arrayOne, $arrayTwo, $arrayThree);
+        $iterator = new ChainIterator([$arrayOne, $arrayTwo, $arrayThree]);
         $expected = [3, 1, 4, 1, 5, 9];
         $this->assertSame($expected, $iterator->toArray());
         // Test again, to cover rewinding.
@@ -48,7 +48,7 @@ final class ChainIteratorTest extends TestCase
      */
     public function testWithoutIterators()
     {
-        $iterator = new ChainIterator();
+        $iterator = new ChainIterator([]);
         $this->assertSame([], $iterator->toArray());
     }
 
@@ -61,8 +61,8 @@ final class ChainIteratorTest extends TestCase
         $arrayTwo = [1, 5, 9];
         $arrayThree = [2, 6, 5];
         $arrayFour = [3, 5, 8];
-        $iterator = new ChainIterator($arrayOne, $arrayTwo);
-        $iterator->append($arrayThree, $arrayFour);
+        $iterator = new ChainIterator([$arrayOne, $arrayTwo]);
+        $iterator->append([$arrayThree, $arrayFour]);
         $expected = [3, 1, 4, 1, 5, 9, 2, 6, 5, 3, 5, 8];
         $this->assertSame($expected, $iterator->toArray());
     }

--- a/tests/src/Iterable/IteratorTraitTest.php
+++ b/tests/src/Iterable/IteratorTraitTest.php
@@ -346,7 +346,7 @@ final class IteratorTraitTest extends TestCase
         $one = new ArrayIterator([3, 1, 4]);
         $two = [1, 5, 9];
         $three = [2, 9, 2];
-        $iterator = $one->zip($two, $three);
+        $iterator = $one->zip([$two, $three]);
         $expected = [[3, 1, 2], [1, 5, 9], [4, 9, 2]];
         $this->assertSame($expected, $iterator->toArray());
     }
@@ -563,7 +563,7 @@ final class IteratorTraitTest extends TestCase
         $arrayTwo = [1, 5, 9];
         $arrayThree = [2, 6, 5];
         $iterator = new ArrayIterator($arrayOne);
-        $chain = $iterator->chain($arrayTwo, $arrayThree);
+        $chain = $iterator->chain([$arrayTwo, $arrayThree]);
         $expected = [3, 1, 4, 1, 5, 9, 2, 6, 5];
         $this->assertSame($expected, iterator_to_array($chain));
     }
@@ -587,7 +587,7 @@ final class IteratorTraitTest extends TestCase
             'four' => 'Chotyry',
         ];
         $iterator = new ArrayIterator($arrayOne);
-        $merge = $iterator->merge($arrayTwo, $arrayThree);
+        $merge = $iterator->merge([$arrayTwo, $arrayThree]);
         $expected = [
             'one' => 'One',
             'two' => 'Dva',

--- a/tests/src/Iterable/ZipIteratorTest.php
+++ b/tests/src/Iterable/ZipIteratorTest.php
@@ -21,7 +21,7 @@ final class ZipIteratorTest extends TestCase
         $one = [3, 1, 4];
         $two = [1, 5, 9];
         $three = [2, 9, 2];
-        $iterator = new ZipIterator($one, $two, $three);
+        $iterator = new ZipIterator([$one, $two, $three]);
         $expected = [[3, 1, 2], [1, 5, 9], [4, 9, 2]];
         $this->assertSame($expected, $iterator->toArray());
     }

--- a/tests/src/Predicate/FunctionsTest.php
+++ b/tests/src/Predicate/FunctionsTest.php
@@ -348,7 +348,7 @@ final class FunctionsTest extends TestCase
      */
     public function testInstanceOf(bool $expected, $value, array $types)
     {
-        $this->assertSame($expected, instance_of(...$types)($value));
+        $this->assertSame($expected, instance_of($types)($value));
     }
 
     /**
@@ -359,7 +359,7 @@ final class FunctionsTest extends TestCase
      */
     public function testAny()
     {
-        $any = any(lt(0), gt(9));
+        $any = any([lt(0), gt(9)]);
         $this->assertTrue($any(-111));
         $this->assertTrue($any(-1));
         $this->assertTrue($any(10));
@@ -377,7 +377,7 @@ final class FunctionsTest extends TestCase
      */
     public function testAll()
     {
-        $all = all(gt(0), lt(9));
+        $all = all([gt(0), lt(9)]);
         $this->assertTrue($all(1));
         $this->assertTrue($all(8));
         $this->assertFalse($all(-111));


### PR DESCRIPTION
This introduces consistent behavior, but makes calling code slightly harder to read, especially for `Iterator` methods that can take multiple other iterables, but are called with just one. Such invocations will look like `$iterator->zip([$other])`, which is not that bad, but slightly harder to read.